### PR TITLE
Fix JCRB FR meeting-48 filename and identifier

### DIFF
--- a/jcrb/meetings-fr/meeting-48.yml
+++ b/jcrb/meetings-fr/meeting-48.yml
@@ -1,8 +1,8 @@
 ---
 metadata:
   title: 48e réunion du JCRB
-  identifier: '482024'
+  identifier: '48'
   date: '2024-09-25'
   source: BIPM - Pavillon de Breteuil
-  url: https://www.bipm.org/fr/committees/jc/jcrb/48-2024-1
+  url: https://www.bipm.org/fr/committees/jc/jcrb/48-2024
 resolutions: []


### PR DESCRIPTION
## Summary

The FR version of JCRB meeting 48 was saved as `meeting-482024.yml`
(concatenating meeting id with year) instead of `meeting-48.yml`,
causing it to mismatch its EN twin and trip Layer 1 of the migration's
validation suite.

Also fixes the inline `identifier: '482024'` to `'48'` and the URL
fragment `/48-2024-1` to `/48-2024` (matching the EN file).

## Test plan

- [x] `ls jcrb/meetings-{en,fr}/meeting-48.yml` matches.
- [x] `head -8 jcrb/meetings-fr/meeting-48.yml` shows `identifier: '48'`.
